### PR TITLE
Add optional sheetName parameter for Excel exports

### DIFF
--- a/.changeset/configurable-sheet-name.md
+++ b/.changeset/configurable-sheet-name.md
@@ -1,0 +1,5 @@
+---
+"export-to-file": minor
+---
+
+Add an optional `sheetName` parameter for xls/xlsx exports (defaults to "data", the previous hard-coded name). Also import `xlsx` via named imports so the ESM build no longer relies on a default export that xlsx's ESM entry doesn't provide.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ import exportToFile from "export-to-file";
 To export data to CSV format, use the `exportToFile` function:
 
 ```javascript
-exportToFile(data, filename, exportType);
+exportToFile(data, filename, exportType, sheetName);
 ```
 
 - `data` (required): The data to be exported.
 - `filename` (required): The name of the exported file.
 - `exportType` (required): The file ending for the file.
   - "CSV", "csv", "EXCEL", "excel", "xls", "XLS", "XLSX", "xlsx"
+- `sheetName` (optional): The name of the worksheet in xls/xlsx exports. Defaults to `"data"`. Ignored for CSV.
 
 ## Example
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { saveAs } from "file-saver";
-import XLSX from "xlsx";
+import { utils, write } from "xlsx";
 
 export type ExportTypes =
   | "CSV"
@@ -14,7 +14,8 @@ export type ExportTypes =
 export default function exportTo(
   data: unknown[],
   fileName: string,
-  exportType: ExportTypes
+  exportType: ExportTypes,
+  sheetName = "data"
 ) {
   let fileExtension = "";
   let blob: Blob;
@@ -27,11 +28,11 @@ export default function exportTo(
     case "XLSX":
     case "EXCEL":
       fileExtension = ".xlsx";
-      blob = exportToXLSX(data);
+      blob = exportToXLSX(data, sheetName);
       break;
     case "XLS":
       fileExtension = ".xls";
-      blob = exportToXLS(data);
+      blob = exportToXLS(data, sheetName);
       break;
     default:
       return;
@@ -40,29 +41,33 @@ export default function exportTo(
   saveAs(blob, fileName + fileExtension);
 }
 
-const defaultExcelBuffer = (csvData: unknown[], isXLSX: boolean) => {
-  const ws = XLSX.utils.json_to_sheet(csvData);
-  const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
-  return XLSX.write(wb, { bookType: isXLSX ? "xlsx" : "xls", type: "array" });
+const defaultExcelBuffer = (
+  csvData: unknown[],
+  isXLSX: boolean,
+  sheetName: string
+) => {
+  const ws = utils.json_to_sheet(csvData);
+  const wb = { Sheets: { [sheetName]: ws }, SheetNames: [sheetName] };
+  return write(wb, { bookType: isXLSX ? "xlsx" : "xls", type: "array" });
 };
 
-const exportToXLSX = (csvData: unknown[]): Blob => {
+const exportToXLSX = (csvData: unknown[], sheetName: string): Blob => {
   const type =
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8";
-  const excelBuffer = defaultExcelBuffer(csvData, true);
+  const excelBuffer = defaultExcelBuffer(csvData, true, sheetName);
   return new Blob([excelBuffer], { type });
 };
 
-const exportToXLS = (csvData: unknown[]): Blob => {
+const exportToXLS = (csvData: unknown[], sheetName: string): Blob => {
   const type = "application/vnd.ms-excel";
-  const excelBuffer = defaultExcelBuffer(csvData, false);
+  const excelBuffer = defaultExcelBuffer(csvData, false, sheetName);
   return new Blob([excelBuffer], { type });
 };
 
 const exportToCsv = (csvData: unknown[]): Blob => {
   const type = "text/plain;charset=UTF-8";
-  const ws = XLSX.utils.json_to_sheet(csvData);
-  const csv = XLSX.utils.sheet_to_csv(ws);
+  const ws = utils.json_to_sheet(csvData);
+  const csv = utils.sheet_to_csv(ws);
 
   return new Blob([csv], { type });
 };


### PR DESCRIPTION
The worksheet name was hard-coded to data. Callers can now pass a fourth argument to name the sheet (still defaults to data). Also switch to named imports from xlsx so the ESM build no longer breaks on xlsx's missing default export.