### PR TITLE
Remove consumed changeset and backfill 1.1.0 changelog

### DIFF
--- a/.changeset/configurable-sheet-name.md
+++ b/.changeset/configurable-sheet-name.md
@@ -1,5 +1,0 @@
----
-"export-to-file": minor
----
-
-Add an optional `sheetName` parameter for xls/xlsx exports (defaults to "data", the previous hard-coded name). Also import `xlsx` via named imports so the ESM build no longer relies on a default export that xlsx's ESM entry doesn't provide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # file-export
 
+## 1.1.0
+
+### Minor Changes
+
+- 33babff: Add an optional `sheetName` parameter for xls/xlsx exports (defaults to "data", the previous hard-coded name). Also import `xlsx` via named imports so the ESM build no longer relies on a default export that xlsx's ESM entry doesn't provide.
+
 ## 1.0.2
 
 ### Patch Changes


### PR DESCRIPTION
The 1.1.0 version bump was applied manually, so the pending changeset file was never consumed by "changeset version". Its presence makes the changesets action try to open a Version Packages PR instead of running the publish step, which is why 1.1.0 never reached npm. Removing it lets the Publish workflow run "changeset publish" on the next push to main.